### PR TITLE
Make the codemod more robust by recursively generating optional chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier": "^1.18.2"
   },
   "engines": {
-    "node": "8.* || 10.* || >= 12"
+    "node": ">= 12"
   },
   "jest": {
     "testEnvironment": "node"

--- a/transforms/optional-chaining/index.js
+++ b/transforms/optional-chaining/index.js
@@ -161,10 +161,11 @@ function transformLogicalExpressions(j, root) {
       return first.segment;
     }
 
-    let subExp = segmentsToMembers(j, leading);
-    console.log('leading', leading, first);
+    let subExp = segmentsToMembers(j, [first, ...endlessTail]);
+    let subExpNext = endlessTail[endlessTail.length - 1];
 
-    if (first.maybeFalsey) {
+    console.log(first, last);
+    if (subExpNext && subExpNext.maybeFalsey) {
       return j.optionalMemberExpression(subExp, j.identifier(last.segment.name));
     }
 

--- a/transforms/optional-chaining/index.js
+++ b/transforms/optional-chaining/index.js
@@ -141,7 +141,7 @@ function transformLogicalExpressions(j, root) {
       }
       return;
     } else if (left.type === 'MemberExpression' || left.type === 'OptionalMemberExpression') {
-      walkTheLeft(left.object, tokenizedRight, offset);
+      //walkTheLeft(left.object, tokenizedRight, offset);
       walkTheLeft(left.property, tokenizedRight, offset + 1);
       return;
     }
@@ -155,12 +155,14 @@ function transformLogicalExpressions(j, root) {
     }
     let [first] = segments;
     let [last, ...leading] = [...segments].reverse();
+    leading.reverse();
 
     if (first === last || leading.length === 0) {
       return first.segment;
     }
 
     let subExp = segmentsToMembers(j, leading);
+    console.log('leading', leading, first);
 
     if (first.maybeFalsey) {
       return j.optionalMemberExpression(subExp, j.identifier(last.segment.name));


### PR DESCRIPTION
before this PR, the codemod only handles single LogicalExpressions (a && a.b).

The aim of this PR is to handle n-length LogicalExpressions (a && a.b && a.b.c && a.b.c.etc)